### PR TITLE
print array in 2-char hex

### DIFF
--- a/AES.cpp
+++ b/AES.cpp
@@ -547,7 +547,7 @@ void AES::printArray(byte output[],int sizel)
 {
   for (int i = 0; i < sizel; i++)
   {
-    printf_P(PSTR("%x"),output[i]);
+    printf_P(PSTR("%02x"),output[i]); // print hex in fixed 2-cgar format
   }
   printf_P(PSTR("\n"));
 }


### PR DESCRIPTION
Improved the function "printArray(byte output[],int sizel)" to print hex values < 0x10 with leading zero.