### PR TITLE
Fix padding for multiples of N_BLOCK and pad length calculation

### DIFF
--- a/AES.cpp
+++ b/AES.cpp
@@ -247,6 +247,7 @@ AES::AES(){
 	arr_pad[12] = 0x0d;
 	arr_pad[13] = 0x0e;
 	arr_pad[14] = 0x0f;
+	arr_pad[15] = 0x10;
 }
 
 /******************************************************************************/
@@ -489,13 +490,8 @@ void AES::get_IV(byte *out){
 /******************************************************************************/
 
 void AES::calc_size_n_pad(int p_size){
-	int s_of_p = p_size - 1;
-	if ( s_of_p % N_BLOCK == 0){
-      size = s_of_p;
-	}else{
-		size = s_of_p +  (N_BLOCK-(s_of_p % N_BLOCK));
-	}
-	pad = size - s_of_p;
+    pad = N_BLOCK - p_size % N_BLOCK;
+    size = p_size + pad;
 }
 
 /******************************************************************************/
@@ -511,15 +507,11 @@ void AES::padPlaintext(void* in,byte* out)
 /******************************************************************************/
 
 bool AES::CheckPad(byte* in,int lsize){
-	if (in[lsize-1] <= 0x0f){
-		int lpad = (int)in[lsize-1];
-		for (int i = lsize - 1; i >= lsize-lpad; i--){
-			if (arr_pad[lpad - 1] != in[i]){
-				return false;
-			}
+	int lpad = (int)in[lsize-1];
+	for (int i = lsize - 1; i >= lsize-lpad; i--){
+		if (arr_pad[lpad - 1] != in[i]){
+			return false;
 		}
-	}else{
-		return true;
 	}
 return true;
 }

--- a/AES.cpp
+++ b/AES.cpp
@@ -513,6 +513,7 @@ bool AES::CheckPad(byte* in,int lsize){
 			if (arr_pad[lpad - 1] != in[i]){
 				return false;
 			}
+		}
 	}else{
 		return true;
 	}

--- a/AES.cpp
+++ b/AES.cpp
@@ -507,11 +507,14 @@ void AES::padPlaintext(void* in,byte* out)
 /******************************************************************************/
 
 bool AES::CheckPad(byte* in,int lsize){
-	int lpad = (int)in[lsize-1];
-	for (int i = lsize - 1; i >= lsize-lpad; i--){
-		if (arr_pad[lpad - 1] != in[i]){
-			return false;
-		}
+	if (in[lsize-1] <= 0x10){
+		int lpad = (int)in[lsize-1];
+		for (int i = lsize - 1; i >= lsize-lpad; i--){
+			if (arr_pad[lpad - 1] != in[i]){
+				return false;
+			}
+	}else{
+		return true;
 	}
 return true;
 }

--- a/AES.h
+++ b/AES.h
@@ -304,9 +304,9 @@ class AES
   int size;/**< hold the size of the plaintext to be ciphered */
   #if defined(AES_LINUX)
 	timeval tv;/**< holds the time value on linux */
-	byte arr_pad[15];/**< holds the hexadecimal padding values on linux */
+	byte arr_pad[16];/**< holds the hexadecimal padding values on linux */
   #else
-	byte arr_pad[15] = { 0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08,0x09,0x0a,0x0b,0x0c,0x0d,0x0e,0x0f };/**< holds the hexadecimal padding values */
+	byte arr_pad[16] = { 0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08,0x09,0x0a,0x0b,0x0c,0x0d,0x0e,0x0f,0x10 };/**< holds the hexadecimal padding values */
   #endif
 } ;
 

--- a/examples/aes/aes.pde
+++ b/examples/aes/aes.pde
@@ -6,17 +6,22 @@ AES aes ;
 byte *key = (unsigned char*)"0123456789010123";
 
 byte plain[] = "Add NodeAdd NodeAdd NodeAdd NodeAdd Node";
+int plainLength = sizeof(plain)-1;  // don't count the trailing /0 of the string !
+int padedLength = plainLength + N_BLOCK - plainLength % N_BLOCK;
 
 //real iv = iv x2 ex: 01234567 = 0123456701234567
 unsigned long long int my_iv = 36753562;
 
 void setup ()
 {
-  Serial.begin (57600) ;
+  Serial.begin (57600);
+  while (!Serial) {
+    ; // wait for serial port to connect. Needed for Leonardo only
+  }
   printf_begin();
   delay(500);
-  printf("\n===testng mode\n") ;
-  
+  printf("\n===testing mode\n") ;
+
 //  otfly_test () ;
 //  otfly_test256 () ;
 }
@@ -31,19 +36,19 @@ void prekey (int bits)
 {
   aes.iv_inc();
   byte iv [N_BLOCK] ;
-  byte plain_p[48];
-  byte cipher [48] ;
-  byte check [48] ;
+  byte plain_p[padedLength];
+  byte cipher [padedLength] ;
+  byte check [padedLength] ;
   unsigned long ms = micros ();
   aes.set_IV(my_iv);
   aes.get_IV(iv);
-  aes.do_aes_encrypt(plain,41,cipher,key,bits,iv);
+  aes.do_aes_encrypt(plain,plainLength,cipher,key,bits,iv);
   Serial.print("Encryption took: ");
   Serial.println(micros() - ms);
   ms = micros ();
   aes.set_IV(my_iv);
   aes.get_IV(iv);
-  aes.do_aes_decrypt(cipher,48,check,key,bits,iv);
+  aes.do_aes_decrypt(cipher,padedLength,check,key,bits,iv);
   Serial.print("Decryption took: ");
   Serial.println(micros() - ms);
   printf("\n\nPLAIN :");

--- a/examples_Rpi/aes.cpp
+++ b/examples_Rpi/aes.cpp
@@ -9,13 +9,15 @@ void prekey (int bits, int blocks);
 byte key[] = "01234567899876543210012345678998";
 
 byte plain[] = "TESTTESTTESTTESTTESTTESTTESTTESTTESTTESTTESTTESTTESTTESTTEST";
+int plainLength = sizeof(plain)-1;  // don't count the trailing /0 of the string !
+int padedLength = plainLength + N_BLOCK - plainLength % N_BLOCK;
 
 //real iv = iv x2 ex: 01234567 = 0123456701234567
 unsigned long long int my_iv = 01234567;
 
 int main(int argc, char** argv)
 {
-  printf("\n===testng mode\n") ;
+  printf("\n===testing mode\n") ;
 
   for (int i=0;i<1;i++){
     prekey_test () ;
@@ -25,9 +27,9 @@ int main(int argc, char** argv)
 void prekey (int bits)
 {
   byte iv [N_BLOCK] ;
-  byte plain_p[sizeof(plain) + (N_BLOCK - (sizeof(plain) % 16)) - 1];
-  byte cipher[sizeof(plain_p)];
-  aes.do_aes_encrypt(plain,sizeof(plain),cipher,key,bits);
+  byte plain_p[padedLength];
+  byte cipher[padedLength];
+  aes.do_aes_encrypt(plain,plainLength,cipher,key,bits);
   aes.get_IV(iv);
   aes.do_aes_decrypt(cipher,aes.get_size(),plain_p,key,bits,iv);
   //normally u have sizeof(cipher) but if its in the same sketch you cannot determin it dynamically


### PR DESCRIPTION
I combined ideas from the pull requests #15 and #16 and updated the examples accordingly.
I tested the code on Arduino Leonardo and Raspberry Pi 1B+

Summary of changes:
* The length of the plain data must be calculates without the trailing \0 added by string assignments
  * Note that the function `sizeof()` includes the \0, so -1 needs to be subtracted for the correct plain data length in case of string input. The function `strlen()` doesn't count the \0.
  * The "-1" was incorrectly in the function `calc_size_n_pad`, instead the input length in the example code has been corrected.
* If the length of the plain data is a multiple of N_BLOCK, a full block of padding must be added (instead of none)
* Some small code improvements