### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,7 +1,7 @@
-AES KEYWORD1
-set_key KEYWORD2
-clean KEYWORD2
-encrypt KEYWORD2
-decrypt KEYWORD2
-cbc_encrypt KEYWORD2
-cbc_decrypt KEYWORD2
+AES	KEYWORD1
+set_key	KEYWORD2
+clean	KEYWORD2
+encrypt	KEYWORD2
+decrypt	KEYWORD2
+cbc_encrypt	KEYWORD2
+cbc_decrypt	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords